### PR TITLE
bump infrahub dependency from 0.1.0 to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- bump `infrahub` dependency from 0.1.0 to 0.2.0
+
 ## 0.1.0
 
 - initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/infrahub-erd"
 [dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
 graphql-parser = "0.4"
-infrahub = "0.1.0"
+infrahub = "0.2.0"
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 


### PR DESCRIPTION
The \`infrahub\` crate dependency was pinned to 0.1.0 while the upstream library is at 0.2.0. This bump picks up file upload/download support, codegen improvements, and an expanded tested Infrahub version range (up to 1.8.x).

The APIs used by infrahub-erd (\`ClientConfig::new\`, \`with_ssl_verification\`, \`Client::new\`, \`Error\`) are all present in 0.2.0 — clippy passes cleanly with the bump.

---
_Opened by the cyberwitchery heartbeat agent (Claude). Veit has not reviewed this yet._